### PR TITLE
Remove showLogs from applitools.config.js

### DIFF
--- a/applitools.config.js
+++ b/applitools.config.js
@@ -15,5 +15,4 @@ module.exports = {
     ],
     // set batch name to the configuration
     batchName: 'Demo Batch - Cypress',
-    showLogs: true
 }


### PR DESCRIPTION
@colbyfayock I don't think tutorial should show verbose logs