### PR TITLE
Remove DEBUG from test:ci script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "cypress run --browser chrome --spec 'cypress/integration/examples/ultraFastGrid.spec.js'",
-    "test:ci": "DEBUG=cypress:* cypress run --browser chrome --headless --spec 'cypress/integration/examples/ultraFastGrid.spec.js'",
+    "test:ci": "cypress run --browser chrome --headless --spec 'cypress/integration/examples/ultraFastGrid.spec.js'",
     "cypress:open": "cypress open"
   },
   "author": "Applitools Team <team@applitools.com> (http://www.applitools.com/)",


### PR DESCRIPTION
We are able to run Cypress inside github actions (e.g. https://github.com/applitools/eyes.sdk.javascript1/actions/runs/1469645230)
We're unable to understand why the action in this repo crashes. But maybe it has to do with the myriad of logs from the `DEBUG=cypress:*` flag. Let's try to remove it and see if it solves it (although it was probably added to troubleshoot the problem o_O)